### PR TITLE
HVPM: Correct raw_from_amps implementation

### DIFF
--- a/Monsoon/HVPM.py
+++ b/Monsoon/HVPM.py
@@ -78,7 +78,7 @@ class Monsoon(object):
         return result
 
     def raw_from_amps(self,value):
-        result = 65535 - 0x0F00 * (value / 65535) + 0x0F00
+        result = (65535 * value / 15.625)
         return result
 
     def setVout(self,value):


### PR DESCRIPTION
Taking an input of amps, the correct behavior for raw_from_amps is seen when
calculating the raw value as: (65535 * amps / 15.625)