### PR TITLE
Drop casting of time.time() to int, during sample collection.

### DIFF
--- a/Monsoon/sampleEngine.py
+++ b/Monsoon/sampleEngine.py
@@ -545,7 +545,7 @@ class SampleEngine:
             Sample = self.monsoon.swizzlePacket(buf)
             numSamples = Sample[2]
             if (legacy_timestamp):
-                Sample.append(int(time.time()))
+                Sample.append(time.time())
             else:
                 Sample.append(time.time() - self.__startTime)
             Samples[S] = Sample


### PR DESCRIPTION
Currently, when collecting samples, and when legacy_timestamp has been set to True, the time.time() value is cast to int, which is reducing the precision of the timestamp. There does not seem to be any reason to return an int for timestamp. And, the documentation for the function mentions that if legacy_timestamp is set to True, it will return time.time(). So this change is more accurate given existing docstring, and will increase the precision of the timestamp value returned.