### PR TITLE
Update pmapi.py to use a value comparison in Windows check

### DIFF
--- a/Monsoon/pmapi.py
+++ b/Monsoon/pmapi.py
@@ -227,7 +227,7 @@ class CPP_Backend_Protocol(object):
         path = os.path.dirname(path)
         if(platform.system() == "Linux"):
             libLocation=os.path.join(path,"Compiled/Linux/libcpp_backend.so")
-        elif(platform.system() is "Windows"):
+        elif(platform.system() == "Windows"):
             libLocation = os.path.join(path,"Compiled//WIN32//Cpp_backend.dll")
         else:
             raise NotImplementedError("OS not currently supported.")


### PR DESCRIPTION
`is` will return `False` even if the values match if it's not the same object in memory.